### PR TITLE
fix: className conflict to keyword like constuctor or toString

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,8 +58,7 @@ const processor = postcss.plugin('postcss-modules-scope', function(options) {
     const generateScopedName =
       (options && options.generateScopedName) || processor.generateScopedName;
 
-    let exports = Object.create(null);
-    // let exports = {};
+    const exports = Object.create(null);
 
     function exportScopedName(name) {
       const scopedName = generateScopedName(

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,7 @@ const processor = postcss.plugin('postcss-modules-scope', function(options) {
       (options && options.generateScopedName) || processor.generateScopedName;
 
     let exports = Object.create(null);
+    // let exports = {};
 
     function exportScopedName(name) {
       const scopedName = generateScopedName(

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ const processor = postcss.plugin('postcss-modules-scope', function(options) {
     const generateScopedName =
       (options && options.generateScopedName) || processor.generateScopedName;
 
-    const exports = {};
+    let exports = Object.create(null);
 
     function exportScopedName(name) {
       const scopedName = generateScopedName(

--- a/test/test-cases/export-keywords-selector/expected.css
+++ b/test/test-cases/export-keywords-selector/expected.css
@@ -1,0 +1,12 @@
+._input__constructor {
+  color: green;
+}
+
+._input__toString {
+  color: red;
+}
+
+:export {
+  constructor: _input__constructor;
+  toString: _input__toString;
+}

--- a/test/test-cases/export-keywords-selector/source.css
+++ b/test/test-cases/export-keywords-selector/source.css
@@ -1,0 +1,7 @@
+:local(.constructor) {
+  color: green;
+}
+
+:local(.toString) {
+  color: red;
+}


### PR DESCRIPTION
Third part lib like `monaco-editor` has the css selector name like [.constructor](https://github.com/Microsoft/vscode/blob/master/src/vs/editor/contrib/suggest/media/suggest.css#L179) which  conflict with `Object`'s keywords.😂