### PR TITLE
Fix for constructor class names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,9 @@ const processor = postcss.plugin('postcss-modules-scope', function(options) {
         css.source.input.css
       );
       exports[name] = exports[name] || [];
+      if (typeof exports[name] === 'function') {
+        exports[name] = [];
+      }
       if (exports[name].indexOf(scopedName) < 0) {
         exports[name].push(scopedName);
       }


### PR DESCRIPTION
Weird thing I run in today, was using https://github.com/Microsoft/monaco-editor-webpack-plugin to load up monaco and seems like monaco has css classes called "constructor". This lead to errors since:

```
exports[name] = exports[name] || [];
```

would evaluate to the constructor function. Meaning that the next line:

```
exports[name].indexOf(scopedName)
```

would throw a type error since Function.indexOf is not a function. The PR solves this issue, let me know if anyone has a better solution for it.