### PR TITLE
Add option to eliminate unused classes from DOM

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,7 @@ const plugin = (options = {}) => {
                 throw new Error('Unexpected comma (",") in :local block');
               }
 
-              const selector = localizeNode(node.first, node.spaces);
+              const selector = localizeNode(node.first);
               // move the spaces that were around the psuedo selector to the first
               // non-container node
               selector.first.spaces = node.spaces;

--- a/test/test-cases/error-composes-not-defined-class-option-exportEmptyLocals-false/expected.error.txt
+++ b/test/test-cases/error-composes-not-defined-class-option-exportEmptyLocals-false/expected.error.txt
@@ -1,0 +1,1 @@
+referenced class name "otherClassName" in composes not found

--- a/test/test-cases/error-composes-not-defined-class-option-exportEmptyLocals-false/options.js
+++ b/test/test-cases/error-composes-not-defined-class-option-exportEmptyLocals-false/options.js
@@ -1,0 +1,3 @@
+module.exports = {
+  exportEmptyLocals: false,
+};

--- a/test/test-cases/error-composes-not-defined-class-option-exportEmptyLocals-false/source.css
+++ b/test/test-cases/error-composes-not-defined-class-option-exportEmptyLocals-false/source.css
@@ -1,0 +1,3 @@
+:local(.className) {
+  composes: otherClassName;
+}

--- a/test/test-cases/options-exportEmptyLocals-false/expected.css
+++ b/test/test-cases/options-exportEmptyLocals-false/expected.css
@@ -1,0 +1,34 @@
+/* leaf node with contents */
+._input__layer1A {
+  color: red;
+}
+
+._input__layer2A /* doesn't add anything new */ {
+}
+
+._input__layer1B {
+  /* totally empty, except for this comment */
+}
+
+._input__layer2B {
+  background: blue;
+}
+
+._input__layer3 {
+}
+
+._input__foo  > ._input__bar {
+}
+
+._input__baz  > ._input__qux {
+  font-style: italic;
+}
+
+:export {
+  layer1A: _input__layer1A;
+  layer2A: _input__layer1A;
+  layer2B: _input__layer2B;
+  layer3: _input__layer1A _input__layer2B;
+  baz: _input__baz;
+  qux: _input__qux;
+}

--- a/test/test-cases/options-exportEmptyLocals-false/options.js
+++ b/test/test-cases/options-exportEmptyLocals-false/options.js
@@ -1,0 +1,3 @@
+module.exports = {
+  exportEmptyLocals: false,
+};

--- a/test/test-cases/options-exportEmptyLocals-false/source.css
+++ b/test/test-cases/options-exportEmptyLocals-false/source.css
@@ -1,0 +1,29 @@
+/* leaf node with contents */
+:local(.layer1A) {
+  color: red;
+}
+
+:local(.layer2A) /* doesn't add anything new */ {
+  composes: layer1A;
+}
+
+:local(.layer1B) {
+  /* totally empty, except for this comment */
+}
+
+:local(.layer2B) {
+  background: blue;
+  composes: layer1B;
+}
+
+:local(.layer3) {
+  composes: layer2A;
+  composes: layer2B;
+}
+
+:local(.foo) /* empty */ > :local(.bar) {
+}
+
+:local(.baz) /* non-empty */ > :local(.qux) {
+  font-style: italic;
+}

--- a/test/test-cases/options-exportEmptyLocals-true/expected.css
+++ b/test/test-cases/options-exportEmptyLocals-true/expected.css
@@ -1,0 +1,37 @@
+/* leaf node with contents */
+._input__layer1A {
+  color: red;
+}
+
+._input__layer2A /* doesn't add anything new */ {
+}
+
+._input__layer1B {
+  /* totally empty, except for this comment */
+}
+
+._input__layer2B {
+  background: blue;
+}
+
+._input__layer3 {
+}
+
+._input__foo  > ._input__bar {
+}
+
+._input__baz  > ._input__qux {
+  font-style: italic;
+}
+
+:export {
+  layer1A: _input__layer1A;
+  layer2A: _input__layer2A _input__layer1A;
+  layer1B: _input__layer1B;
+  layer2B: _input__layer2B _input__layer1B;
+  layer3: _input__layer3 _input__layer2A _input__layer1A _input__layer2B _input__layer1B;
+  foo: _input__foo;
+  bar: _input__bar;
+  baz: _input__baz;
+  qux: _input__qux;
+}

--- a/test/test-cases/options-exportEmptyLocals-true/source.css
+++ b/test/test-cases/options-exportEmptyLocals-true/source.css
@@ -1,0 +1,29 @@
+/* leaf node with contents */
+:local(.layer1A) {
+  color: red;
+}
+
+:local(.layer2A) /* doesn't add anything new */ {
+  composes: layer1A;
+}
+
+:local(.layer1B) {
+  /* totally empty, except for this comment */
+}
+
+:local(.layer2B) {
+  background: blue;
+  composes: layer1B;
+}
+
+:local(.layer3) {
+  composes: layer2A;
+  composes: layer2B;
+}
+
+:local(.foo) /* empty */ > :local(.bar) {
+}
+
+:local(.baz) /* non-empty */ > :local(.qux) {
+  font-style: italic;
+}


### PR DESCRIPTION
I'm new to this repository (never even having heard of CSS Modules a week ago), so please review this pull request carefully.

# References
* css-modules/css-modules#127
* css-modules/css-modules#269

# Concerns
## Naming
I'm not 100% certain about the option name `exportEmptyLocals`. I first planned to call it `omitEmptyLocals` so that `false` could be the default, but when reviewing `css-loader`'s set of related options (`exportGlobals`, `exportLocalsConvention`, `exportOnlyLocals`) the former one seemed more suitable. Furthermore, if this option will someday be the default, "omit" would be even more awkward. Still, this name doesn't tell the full story.

## DOM-only fix
This fix only filters the exports, i.e. what ends up in the DOM. There are other tools available to strip CSS of empty declaration blocks, but please let me know if you think that such functionality nevertheless belongs here.

## Side effects of empty imports
An imported selector with an empty declaration block (i.e. that doesn't contain any declarations nor a `composes` specifying another selector that does) renders as `undefined`. On the other hand, this is what happens already today when importing a non-existent selector. If the behavior is undesirable, it should probably be fixed in `postcss-modules-extract-imports`.

# Other requirements
I believe that the correct approach would be to add an option to `css-loader` to make this configurable, which is then passed on to `postcss-modules-scope`. I have written that code but would like to see what happens with this pull request before creating another one.