### PR TITLE
fix: use `onceexit` (instead of `once`) which runs after all children are processed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ const plugin = (options = {}) => {
 
   return {
     postcssPlugin: "postcss-modules-scope",
-    Once(root, { rule }) {
+    OnceExit(root, { rule }) {
       const exports = Object.create(null);
 
       function exportScopedName(name, rawName) {


### PR DESCRIPTION
See: https://postcss.org/api/#plugin-onceexit

This gives other postcss plugins (like postcss-each) a chance to run first and modify the AST.